### PR TITLE
Dump current parse position when an error occurs.

### DIFF
--- a/rpc/client.cc
+++ b/rpc/client.cc
@@ -107,7 +107,7 @@ int Client::connect(const char* addr) {
 
     if (rp == NULL) {
         // failed to connect
-        Log::error("rpc::Client: connect(): %s", strerror(errno));
+        Log::error("rpc::Client: connect(%s): %s", addr, strerror(errno));
         return -1;
     }
 

--- a/rpc/client.h
+++ b/rpc/client.h
@@ -79,6 +79,31 @@ public:
     }
 };
 
+class FutureGroup {
+private:
+  std::vector<Future*> futures_;
+
+public:
+  void add(Future* f) {
+    if (f == NULL) {
+      Log::fatal("Null future passed to FutureGroup");
+    }
+    futures_.push_back(f);
+  }
+
+  void wait_all() {
+    for (auto f : futures_) {
+      f->wait();
+    }
+  }
+
+  ~FutureGroup() {
+    for (auto f : futures_) {
+      f->release();
+    }
+  }
+};
+
 class Client: public Pollable {
     Marshal in_, out_;
 

--- a/rpc/rpcgen.g
+++ b/rpc/rpcgen.g
@@ -179,7 +179,7 @@ def emit_service_and_proxy(service, f):
             else:
                 postfix = ""
             if func.attr == "raw":
-                f.writeln("virtual void %s(rpc::Request* req, rpc::ServerConnection* sconn)%s;" % (func.name, postfix))
+                f.writeln("virtual void %s(rpc::Request* req, rpc::ServerConnection* sconn)%s = 0;" % (func.name, postfix))
             else:
                 func_args = []
                 for in_arg in func.input:
@@ -192,7 +192,7 @@ def emit_service_and_proxy(service, f):
                         func_args += "%s* %s" % (out_arg.type, out_arg.name),
                     else:
                         func_args += "%s*" % out_arg.type,
-                f.writeln("virtual void %s(%s)%s;" % (func.name, ", ".join(func_args), postfix))
+                f.writeln("virtual void %s(%s)%s = 0;" % (func.name, ", ".join(func_args), postfix))
     f.writeln("private:")
     with f.indent():
         for func in service.functions:
@@ -319,13 +319,8 @@ def rpcgen(rpc_fpath):
         f.writeln()
         f.writeln("#pragma once")
         f.writeln()
-        f.writeln("#ifndef RPC_SERVER_H_")
-        f.writeln("#error please include server.h before including this file")
-        f.writeln("#endif // RPC_SERVER_H_")
-        f.writeln()
-        f.writeln("#ifndef RPC_CLIENT_H_")
-        f.writeln("#error please include client.h before including this file")
-        f.writeln("#endif // RPC_CLIENT_H_")
+        f.writeln("#include \"rpc/server.h\"")
+        f.writeln("#include \"rpc/client.h\"")
         f.writeln()
         f.writeln("#include <errno.h>")
         f.writeln()

--- a/rpc/rpcgen.g
+++ b/rpc/rpcgen.g
@@ -5,6 +5,14 @@ import os
 import re
 sys.path += os.path.abspath(os.path.join(os.path.split(__file__)[0], "../pylib")),
 
+
+def error(msg, ctx):
+  from yapps import runtime
+  err = runtime.SyntaxError(None, msg, ctx)
+  runtime.print_error(err, ctx.scanner)
+  sys.exit(1)
+
+
 class pack:
     def __init__(self, **kv):
         self.__dict__.update(kv)
@@ -60,7 +68,7 @@ parser Rpc:
         | "i64" {{ return "rpc::i64" }}
         | full_symbol {{ t = std_rename(full_symbol) }}
             ["<" type {{ t += "<" + type }} ("," type {{ t += ", " + type }})* ">" {{ t += ">" }}] {{ return t }}
-        | ("bool" | "int" | "unsigned" | "long" ) {{ raise TypeError("please use i32 or i64 for any integer types") }}
+        | ("bool" | "int" | "unsigned" | "long" ) {{ error("please use i32 or i64 for any integer types", _context) }}
 
     rule full_symbol: {{ s = "" }}
         ["::" {{ s += "::" }}] SYMBOL {{ s += SYMBOL }} ("::" SYMBOL {{ s += "::" + SYMBOL }})*

--- a/rpc/rpcgen.py
+++ b/rpc/rpcgen.py
@@ -5,6 +5,14 @@ import os
 import re
 sys.path += os.path.abspath(os.path.join(os.path.split(__file__)[0], "../pylib")),
 
+
+def error(msg, ctx):
+  from yapps import runtime
+  err = runtime.SyntaxError(None, msg, ctx)
+  runtime.print_error(err, ctx.scanner)
+  sys.exit(1)
+
+
 class pack:
     def __init__(self, **kv):
         self.__dict__.update(kv)
@@ -151,7 +159,7 @@ class Rpc(runtime.Parser):
                 self._scan('"unsigned"', context=_context)
             else: # == '"long"'
                 self._scan('"long"', context=_context)
-            raise TypeError("please use i32 or i64 for any integer types")
+            error("please use i32 or i64 for any integer types", _context)
 
     def full_symbol(self, _parent=None):
         _context = self.Context(_parent, self._scanner, 'full_symbol', [])

--- a/rpc/rpcgen.py
+++ b/rpc/rpcgen.py
@@ -336,7 +336,7 @@ def emit_service_and_proxy(service, f):
             else:
                 postfix = ""
             if func.attr == "raw":
-                f.writeln("virtual void %s(rpc::Request* req, rpc::ServerConnection* sconn)%s;" % (func.name, postfix))
+                f.writeln("virtual void %s(rpc::Request* req, rpc::ServerConnection* sconn)%s = 0;" % (func.name, postfix))
             else:
                 func_args = []
                 for in_arg in func.input:
@@ -349,7 +349,7 @@ def emit_service_and_proxy(service, f):
                         func_args += "%s* %s" % (out_arg.type, out_arg.name),
                     else:
                         func_args += "%s*" % out_arg.type,
-                f.writeln("virtual void %s(%s)%s;" % (func.name, ", ".join(func_args), postfix))
+                f.writeln("virtual void %s(%s)%s = 0;" % (func.name, ", ".join(func_args), postfix))
     f.writeln("private:")
     with f.indent():
         for func in service.functions:
@@ -476,13 +476,8 @@ def rpcgen(rpc_fpath):
         f.writeln()
         f.writeln("#pragma once")
         f.writeln()
-        f.writeln("#ifndef RPC_SERVER_H_")
-        f.writeln("#error please include server.h before including this file")
-        f.writeln("#endif // RPC_SERVER_H_")
-        f.writeln()
-        f.writeln("#ifndef RPC_CLIENT_H_")
-        f.writeln("#error please include client.h before including this file")
-        f.writeln("#endif // RPC_CLIENT_H_")
+        f.writeln("#include \"rpc/server.h\"")
+        f.writeln("#include \"rpc/client.h\"")
         f.writeln()
         f.writeln("#include <errno.h>")
         f.writeln()

--- a/rpc/utils.h
+++ b/rpc/utils.h
@@ -331,5 +331,8 @@ private:
 
 int set_nonblocking(int fd, bool nonblocking);
 
+int find_open_port();
+std::string get_host_name();
+
 }
 

--- a/test/synctest.cc
+++ b/test/synctest.cc
@@ -1,0 +1,61 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <semaphore.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <signal.h>
+#include <vector>
+#include <map>
+
+#include "rpc/client.h"
+#include "rpc/server.h"
+#include "demo_service.h"
+
+#define NUM 10000000
+
+using namespace demo;
+using namespace rpc;
+using namespace std;
+
+char buffer[1024];
+char* fmt(const char* fmt, ...) {
+  va_list l;
+  va_start(l, fmt);
+  vsprintf(buffer, fmt, l);
+  va_end(l);
+  return buffer;
+}
+
+DemoProxy* start_server(int port) {
+  auto poll = new PollMgr();
+  auto pool = new ThreadPool(8);
+  auto svc = new DemoService();
+  auto server = new Server(poll, pool);
+  server->reg(svc);
+  server->start(fmt("localhost:%d", port));
+
+  auto client = new Client(poll);
+  client->connect(fmt("localhost:%d", port));
+  return new DemoProxy(client);
+}
+
+int main(int argc, char **argv) {
+  vector<DemoProxy*> servers;
+  for (int i = 0; i < 4; ++i) {
+    servers.push_back(start_server(9999 + i));
+  }
+
+  for (int i = 0; i < 100; ++i) {
+    vector<Future*> f;
+    for (int j = 0; j < 10000; ++j) {
+      f.push_back(servers[j % 4]->async_prime(j));
+      Log::info("Sending... %d", j);
+    }
+
+    for (int k = 0; k < f.size(); ++k) {
+      Log::info("Waiting... %d", k);
+      f[k]->wait();
+      f[k]->release();
+    }
+  }
+}

--- a/wscript
+++ b/wscript
@@ -55,6 +55,7 @@ def build(bld):
     _prog("test/marshal_test.cc", "marshal_test")
     _prog("test/counter_bench.cc", "counter_bench")
     _prog("test/threadpool_bench.cc", "threadpool_bench")
+    _prog("test/synctest.cc test/demo_service.cc", "synctest")
 
     _prog("logservice/log_server.cc", "log_server", use="logservice simplerpc PTHREAD")
     _prog("test/log_client.cc", "log_client", use="logservice simplerpc PTHREAD")


### PR DESCRIPTION
Hey Yang,

This just changes the parser to dump the current position of the parse when it encounters an error, rather then the Python stack:

```
../external/simple-rpc/rpc/rpcgen.py ../sparrow/sparrow_service.rpc
<f.0>:40:7: please use i32 or i64 for any integer types
>    bool done;
>        ^
while parsing type():
>    bool done;
>        ^
while parsing struct_field():
>    bool done;
>        ^
while parsing struct_fields():
>  struct IteratorResp {
>                       ^
while parsing struct_decl():
>  struct IteratorResp {
>        ^
while parsing structs_and_services():
```
