### PR TITLE
Use macros to capture file, line number when logging.

### DIFF
--- a/logservice/log_server.cc
+++ b/logservice/log_server.cc
@@ -16,7 +16,7 @@ RLogService *g_ls = NULL;
 Server *g_server = NULL;
 
 static void signal_handler(int sig) {
-    Log::info("caught signal %d, stopping server now", sig);
+    Log_info("caught signal %d, stopping server now", sig);
     delete g_server;
     delete g_ls;
     exit(0);

--- a/logservice/log_service_impl.cc
+++ b/logservice/log_service_impl.cc
@@ -33,7 +33,7 @@ void RLogServiceImpl::log(const i32& level, const std::string& source, const i64
     i64& done = done_[source];
 
     while (!buffer.empty() && buffer.begin()->msg_id <= done + 1) {
-        Log::log(buffer.begin()->level, "%s.%03d %s: %s", tm_str, tv.tv_usec / 1000, source.c_str(), buffer.begin()->message.c_str());
+        Log::log(buffer.begin()->level, "remote", -1, "%s.%03d %s: %s", tm_str, tv.tv_usec / 1000, source.c_str(), buffer.begin()->message.c_str());
         done = max(done, buffer.begin()->msg_id);
         buffer.erase(buffer.begin());
     }
@@ -82,7 +82,7 @@ void RLogServiceImpl::aggregate_qps(const std::string& metric_name, const rpc::i
         }
         last_qps_report_tm_ = now;
         if (qps_ostr.str().length() > 0) {
-            Log::info("qps '%s':%s", metric_name.c_str(), qps_ostr.str().c_str());
+            Log_info("qps '%s':%s", metric_name.c_str(), qps_ostr.str().c_str());
         }
     }
 

--- a/logservice/rlog.cc
+++ b/logservice/rlog.cc
@@ -41,14 +41,14 @@ void RLog::init(const char* my_ident /* =? */, const char* rlog_addr /* =? */) {
         }
         cl_s = new Client(poll_s);
         if (rlog_addr == NULL || cl_s->connect(rlog_addr) != 0) {
-            Log::info("RLog working in local mode");
+            Log_info("RLog working in local mode");
             do_finalize();
         } else {
             rp_s = new RLogProxy(cl_s);
             msg_counter_s.reset(0);
         }
     } else {
-        Log::warn("called RLog::init() multiple times without calling RLog::finalize() first");
+        Log_warn("called RLog::init() multiple times without calling RLog::finalize() first");
     }
     lock_s.unlock();
 }
@@ -68,7 +68,7 @@ void RLog::log_v(int level, const char* fmt, va_list args) {
         verify(cnt < buf_len_s - 1);
     }
     buf_s[cnt] = '\0';
-    Log::log(level, "%s", buf_s);
+    Log::log(level, "remote", -1, "%s", buf_s);
     if (rp_s) {
         // always use async rpc
         string message = buf_s;
@@ -76,7 +76,7 @@ void RLog::log_v(int level, const char* fmt, va_list args) {
         if (fu != NULL) {
             fu->release();
         } else {
-            Log::error("RLog connection failed, fall back to local mode");
+            Log_error("RLog connection failed, fall back to local mode");
             do_finalize();
         }
     }
@@ -91,11 +91,11 @@ void RLog::aggregate_qps(const std::string& metric_name, const rpc::i32 incremen
         if (fu != NULL) {
             fu->release();
         } else {
-//            Log::error("RLog connection failed, cannot report qps");
+//            Log_error("RLog connection failed, cannot report qps");
             do_finalize();
         }
 //    } else {
-//        Log::error("RLog not initialized, cannot report qps");
+//        Log_error("RLog not initialized, cannot report qps");
     }
     lock_s.unlock();
 }

--- a/rpc/client.cc
+++ b/rpc/client.cc
@@ -68,7 +68,7 @@ int Client::connect(const char* addr) {
     string addr_str(addr);
     size_t idx = addr_str.find(":");
     if (idx == string::npos) {
-        Log::error("rpc::Client: bad connect address: %s", addr);
+        Log_error("rpc::Client: bad connect address: %s", addr);
         errno = EINVAL;
         return -1;
     }
@@ -83,7 +83,7 @@ int Client::connect(const char* addr) {
 
     int r = getaddrinfo(host.c_str(), port.c_str(), &hints, &result);
     if (r != 0) {
-        Log::error("rpc::Client: getaddrinfo(): %s", gai_strerror(r));
+        Log_error("rpc::Client: getaddrinfo(): %s", gai_strerror(r));
         return -1;
     }
 
@@ -107,12 +107,12 @@ int Client::connect(const char* addr) {
 
     if (rp == NULL) {
         // failed to connect
-        Log::error("rpc::Client: connect(%s): %s", addr, strerror(errno));
+        Log_error("rpc::Client: connect(%s): %s", addr, strerror(errno));
         return -1;
     }
 
     verify(set_nonblocking(sock_, true) == 0);
-    Log::info("rpc::Client: connected to %s", addr);
+    Log_info("rpc::Client: connected to %s", addr);
 
     status_ = CONNECTED;
     pollmgr_->add(this);

--- a/rpc/client.h
+++ b/rpc/client.h
@@ -86,7 +86,7 @@ private:
 public:
   void add(Future* f) {
     if (f == NULL) {
-      Log::fatal("Null future passed to FutureGroup");
+      Log_fatal("Null future passed to FutureGroup");
     }
     futures_.push_back(f);
   }

--- a/rpc/marshal.cc
+++ b/rpc/marshal.cc
@@ -26,14 +26,14 @@ static void _pkt_sampling_report() {
                 for (int i = 0; i < PKT_SAMPLE_SIZE; i++) {
                     ostr << " " << _pkt_sample_in_size[i];
                 }
-                Log::info("PKT_SAMPLE_IN: %s", ostr.str().c_str());
+                Log_info("PKT_SAMPLE_IN: %s", ostr.str().c_str());
             }
             {
                 ostringstream ostr;
                 for (int i = 0; i < PKT_SAMPLE_SIZE; i++) {
                     ostr << " " << _pkt_sample_out_size[i];
                 }
-                Log::info("PKT_SAMPLE_OUT:%s", ostr.str().c_str());
+                Log_info("PKT_SAMPLE_OUT:%s", ostr.str().c_str());
             }
             last_report_tm = now.tv_sec;
         }

--- a/rpc/polling.cc
+++ b/rpc/polling.cc
@@ -85,19 +85,19 @@ public:
 
 PollMgr::PollMgr(const poll_options& opts /* =... */): opts_(opts) {
     if (opts_.rate.min_size > 0 && opts_.rate.interval <= 0.0) {
-        Log::warn("rpc batching size set but wait time not set, will use 1ms");
+        Log_warn("rpc batching size set but wait time not set, will use 1ms");
         opts_.rate.interval = 0.001;
     }
     poll_threads_ = new PollThread[opts_.n_threads];
     for (int i = 0; i < opts_.n_threads; i++) {
         poll_threads_[i].start(this);
     }
-    //Log::debug("rpc::PollMgr: start with %d thread", opts_.n_threads);
+    //Log_debug("rpc::PollMgr: start with %d thread", opts_.n_threads);
 }
 
 PollMgr::~PollMgr() {
     delete[] poll_threads_;
-    //Log::debug("rpc::PollMgr: destroyed");
+    //Log_debug("rpc::PollMgr: destroyed");
 }
 
 void PollMgr::PollThread::poll_loop() {

--- a/rpc/server.cc
+++ b/rpc/server.cc
@@ -68,7 +68,7 @@ void ServerConnection::handle_read() {
             verify(req->m.read_from_marshal(in_, packet_size) == (size_t) packet_size);
 
             if (packet_size < (int) sizeof(i64)) {
-                Log::warn("rpc::ServerConnection: got an incomplete packet, xid not included");
+                Log_warn("rpc::ServerConnection: got an incomplete packet, xid not included");
 
                 // Since we don't have xid, we don't know how to notify client about the failure.
                 // All we can do is simply cleanup resource.
@@ -103,7 +103,7 @@ void ServerConnection::handle_read() {
             // the handler should delete req, and release server_connection refcopy.
             it->second->handle(req, (ServerConnection *) this->ref_copy());
         } else {
-            Log::error("rpc::ServerConnection: no handler for rpc_id=%d", rpc_id);
+            Log_error("rpc::ServerConnection: no handler for rpc_id=%d", rpc_id);
             begin_reply(req, ENOENT);
             end_reply();
             delete req;
@@ -152,7 +152,7 @@ void ServerConnection::close() {
         server_->pollmgr_->remove(this);
         server_->sconns_l_.unlock();
 
-        Log::debug("rpc::ServerConnection: closed on fd=%d", socket_);
+        Log_debug("rpc::ServerConnection: closed on fd=%d", socket_);
 
         status_ = CLOSED;
         ::close(socket_);
@@ -220,7 +220,7 @@ Server::~Server() {
         delete it.second;
     }
 
-    //Log::debug("rpc::Server: destroyed");
+    //Log_debug("rpc::Server: destroyed");
 }
 
 struct start_server_loop_args_type {
@@ -263,7 +263,7 @@ void Server::server_loop(struct addrinfo* svr_addr) {
 
         int clnt_socket = accept(server_sock_, svr_addr->ai_addr, &svr_addr->ai_addrlen);
         if (clnt_socket >= 0 && status_ == RUNNING) {
-            Log::debug("rpc::Server: got new client, fd=%d", clnt_socket);
+            Log_debug("rpc::Server: got new client, fd=%d", clnt_socket);
             verify(set_nonblocking(clnt_socket, true) == 0);
 
             sconns_l_.lock();
@@ -283,7 +283,7 @@ int Server::start(const char* bind_addr) {
     string addr(bind_addr);
     size_t idx = addr.find(":");
     if (idx == string::npos) {
-        Log::error("rpc::Server: bad bind address: %s", bind_addr);
+        Log_error("rpc::Server: bad bind address: %s", bind_addr);
         errno = EINVAL;
         return -1;
     }
@@ -299,7 +299,7 @@ int Server::start(const char* bind_addr) {
 
     int r = getaddrinfo((host == "0.0.0.0") ? NULL : host.c_str(), port.c_str(), &hints, &result);
     if (r != 0) {
-        Log::error("rpc::Server: getaddrinfo(): %s", gai_strerror(r));
+        Log_error("rpc::Server: getaddrinfo(): %s", gai_strerror(r));
         return -1;
     }
 
@@ -322,7 +322,7 @@ int Server::start(const char* bind_addr) {
 
     if (rp == NULL) {
         // failed to bind
-        Log::error("rpc::Server: bind(): %s", strerror(errno));
+        Log_error("rpc::Server: bind(): %s", strerror(errno));
         freeaddrinfo(result);
         return -1;
     }
@@ -333,7 +333,7 @@ int Server::start(const char* bind_addr) {
     verify(set_nonblocking(server_sock_, true) == 0);
 
     status_ = RUNNING;
-    Log::info("rpc::Server: started on %s", bind_addr);
+    Log_info("rpc::Server: started on %s", bind_addr);
 
     start_server_loop_args_type* start_server_loop_args = new start_server_loop_args_type();
     start_server_loop_args->server = this;

--- a/rpc/server.h
+++ b/rpc/server.h
@@ -66,7 +66,7 @@ protected:
 
     // Protected destructor as required by RefCounted.
     ~ServerConnection() {
-        //Log::debug("rpc::ServerConnection: destroyed");
+        //Log_debug("rpc::ServerConnection: destroyed");
     }
 
 public:

--- a/rpc/utils.h
+++ b/rpc/utils.h
@@ -49,7 +49,7 @@ class Log {
     static FILE* fp;
     static pthread_mutex_t m;
 
-    static void log_v(int level, const char* fmt, va_list args);
+    static void log_v(int level, const char* file, int line, const char* fmt, va_list args);
 public:
 
     enum {
@@ -58,14 +58,21 @@ public:
 
     static void set_file(FILE* fp);
     static void set_level(int level);
-    static void log(int level, const char* fmt, ...);
+    static void log(int level, const char* file, int line, const char* fmt, ...);
 
-    static void fatal(const char* fmt, ...);
-    static void error(const char* fmt, ...);
-    static void warn(const char* fmt, ...);
-    static void info(const char* fmt, ...);
-    static void debug(const char* fmt, ...);
+    static void fatal(const char* file, int line, const char* fmt, ...);
+    static void error(const char* file, int line, const char* fmt, ...);
+    static void warn(const char* file, int line, const char* fmt, ...);
+    static void info(const char* file, int line, const char* fmt, ...);
+    static void debug(const char* file, int line, const char* fmt, ...);
 };
+
+#define Log_debug(msg, ...) ::rpc::Log::debug(__FILE__, __LINE__, msg, ## __VA_ARGS__)
+#define Log_info(msg, ...) ::rpc::Log::info(__FILE__, __LINE__, msg, ## __VA_ARGS__)
+#define Log_warn(msg, ...) ::rpc::Log::warn(__FILE__, __LINE__, msg, ## __VA_ARGS__)
+#define Log_error(msg, ...) ::rpc::Log::error(__FILE__, __LINE__, msg, ## __VA_ARGS__)
+#define Log_fatal(msg, ...) ::rpc::Log::fatal(__FILE__, __LINE__, msg, ## __VA_ARGS__)
+
 
 class NoCopy {
     NoCopy(const NoCopy&);

--- a/test/counter_bench.cc
+++ b/test/counter_bench.cc
@@ -79,7 +79,7 @@ static void* worker_thread(void* f) {
 }
 
 int main(int argc, char* argv[]) {
-    Log::info("This shall be done!");
+    Log_info("This shall be done!");
     Timer tm;
     volatile int j = 0;
     int n = 1000 * 1000;
@@ -90,7 +90,7 @@ int main(int argc, char* argv[]) {
     }
     tm.end();
     double base = n / tm.elapsed();
-    Log::info("i++ 1 thread: %.2lf/s", base);
+    Log_info("i++ 1 thread: %.2lf/s", base);
     Counter ctr;
     tm.reset();
     tm.start();
@@ -98,7 +98,7 @@ int main(int argc, char* argv[]) {
         ctr.next();
     }
     tm.end();
-    Log::info("Counter 1 thread: %.2lf/s (%.4lf)", n / tm.elapsed(), n / tm.elapsed() / base);
+    Log_info("Counter 1 thread: %.2lf/s (%.4lf)", n / tm.elapsed(), n / tm.elapsed() / base);
     ShortLockCounter s_ctr;
     tm.reset();
     tm.start();
@@ -106,7 +106,7 @@ int main(int argc, char* argv[]) {
         s_ctr.next();
     }
     tm.end();
-    Log::info("ShortLockCounter 1 thread: %.2lf/s (%.4lf)", n / tm.elapsed(), n / tm.elapsed() / base);
+    Log_info("ShortLockCounter 1 thread: %.2lf/s (%.4lf)", n / tm.elapsed(), n / tm.elapsed() / base);
     LongLockCounter l_ctr;
     tm.reset();
     tm.start();
@@ -114,7 +114,7 @@ int main(int argc, char* argv[]) {
         l_ctr.next();
     }
     tm.end();
-    Log::info("LongLockCounter 1 thread: %.2lf/s (%.4lf)", n / tm.elapsed(), n / tm.elapsed() / base);
+    Log_info("LongLockCounter 1 thread: %.2lf/s (%.4lf)", n / tm.elapsed(), n / tm.elapsed() / base);
     AtomicCounter a_ctr;
     tm.reset();
     tm.start();
@@ -122,7 +122,7 @@ int main(int argc, char* argv[]) {
         a_ctr.next();
     }
     tm.end();
-    Log::info("AtomicCounter 1 thread: %.2lf/s (%.4lf)", n / tm.elapsed(), n / tm.elapsed() / base);
+    Log_info("AtomicCounter 1 thread: %.2lf/s (%.4lf)", n / tm.elapsed(), n / tm.elapsed() / base);
     pthread_t* th = new pthread_t[t];
     function<void()> worker1 = [&ctr, n] {
         while (ctr.next() < 2 * n)
@@ -137,7 +137,7 @@ int main(int argc, char* argv[]) {
         Pthread_join(th[i], nullptr);
     }
     tm.end();
-    Log::info("Counter %d thread: %.2lf/s (%.4lf)", t, n / tm.elapsed(), n / tm.elapsed() / base);
+    Log_info("Counter %d thread: %.2lf/s (%.4lf)", t, n / tm.elapsed(), n / tm.elapsed() / base);
     function<void()> worker2 = [&s_ctr, n] {
         while (s_ctr.next() < 2 * n)
             ;
@@ -151,7 +151,7 @@ int main(int argc, char* argv[]) {
         Pthread_join(th[i], nullptr);
     }
     tm.end();
-    Log::info("ShortLockCounter %d thread: %.2lf/s (%.4lf)", t, n / tm.elapsed(), n / tm.elapsed() / base);
+    Log_info("ShortLockCounter %d thread: %.2lf/s (%.4lf)", t, n / tm.elapsed(), n / tm.elapsed() / base);
     function<void()> worker3 = [&l_ctr, n] {
         while (l_ctr.next() < 2 * n)
             ;
@@ -165,7 +165,7 @@ int main(int argc, char* argv[]) {
         Pthread_join(th[i], nullptr);
     }
     tm.end();
-    Log::info("LongLockCounter %d thread: %.2lf/s (%.4lf)", t, n / tm.elapsed(), n / tm.elapsed() / base);
+    Log_info("LongLockCounter %d thread: %.2lf/s (%.4lf)", t, n / tm.elapsed(), n / tm.elapsed() / base);
     function<void()> worker4 = [&a_ctr, n] {
         while (a_ctr.next() < 2 * n)
             ;
@@ -179,7 +179,7 @@ int main(int argc, char* argv[]) {
         Pthread_join(th[i], nullptr);
     }
     tm.end();
-    Log::info("AtomicCounter %d thread: %.2lf/s (%.4lf)", t, n / tm.elapsed(), n / tm.elapsed() / base);
+    Log_info("AtomicCounter %d thread: %.2lf/s (%.4lf)", t, n / tm.elapsed(), n / tm.elapsed() / base);
     delete[] th;
     return 0;
 }

--- a/test/demo_client.cc
+++ b/test/demo_client.cc
@@ -66,7 +66,7 @@ inline void do_work(ClientPool* cl_pool, const char* svr_addr, FutureAttr& fu_at
         fu = DemoProxy(cl).async_large_str_nop(long_str, fu_attr);
         break;
     default:
-        Log::fatal("unexpected code reached!");
+        Log_fatal("unexpected code reached!");
         verify(0);
     }
     if (fu != NULL) {
@@ -95,7 +95,7 @@ int main(int argc, char* argv[]) {
     } else if (streq(argv[2], "large_str_nop")) {
         eval_case = LARGE_STR_NOP;
     } else {
-        Log::fatal("eval case not supported: %s", argv[2]);
+        Log_fatal("eval case not supported: %s", argv[2]);
         exit(1);
     }
 
@@ -117,7 +117,7 @@ int main(int argc, char* argv[]) {
     }
 
     for (int i = 0; i < 20; i++) {
-        Log::debug("clock tick, about %d rpc done", rpc_counter.peek_next());
+        Log_debug("clock tick, about %d rpc done", rpc_counter.peek_next());
         if (g_rpc_issued.peek_next() > g_n_rpc) {
             break;
         }

--- a/test/demo_server.cc
+++ b/test/demo_server.cc
@@ -12,7 +12,7 @@ using namespace demo;
 bool g_stop_flag = false;
 
 static void signal_handler(int sig) {
-    Log::info("caught signal %d, stopping server now", sig);
+    Log_info("caught signal %d, stopping server now", sig);
     g_stop_flag = true;
 }
 

--- a/test/marshal_test.cc
+++ b/test/marshal_test.cc
@@ -6,12 +6,12 @@ using namespace rpc;
 int main() {
     Marshal m;
     rpc::i32 a = 4;
-    Log::debug("content size = %d", m.content_size());
+    Log_debug("content size = %d", m.content_size());
     m << a;
-    Log::debug("content size = %d", m.content_size());
+    Log_debug("content size = %d", m.content_size());
     rpc::i32 b = 9;
     m >> b;
-    Log::debug("content size = %d", m.content_size());
+    Log_debug("content size = %d", m.content_size());
     verify(a == b);
     return 0;
 }

--- a/test/synctest.cc
+++ b/test/synctest.cc
@@ -49,11 +49,11 @@ int main(int argc, char **argv) {
     vector<Future*> f;
     for (int j = 0; j < 10000; ++j) {
       f.push_back(servers[j % 4]->async_prime(j));
-      Log::info("Sending... %d", j);
+      Log_info("Sending... %d", j);
     }
 
     for (int k = 0; k < f.size(); ++k) {
-      Log::info("Waiting... %d", k);
+      Log_info("Waiting... %d", k);
       f[k]->wait();
       f[k]->release();
     }

--- a/test/threadpool_bench.cc
+++ b/test/threadpool_bench.cc
@@ -19,7 +19,7 @@ int main(int argc, char* argv[]) {
     }
     thrpool->release();
     timer.end();
-    Log::info("running %d nop_jobs in ThreadPool(%d) took %lf seconds, throughput=%lf (1 issuing thread)",
+    Log_info("running %d nop_jobs in ThreadPool(%d) took %lf seconds, throughput=%lf (1 issuing thread)",
         n_jobs, threadpool_size, timer.elapsed(), n_jobs / timer.elapsed());
 
 }


### PR DESCRIPTION
Yang,

This just switches the Logger to use some macros which give the file and line number when logging.  Not as pretty, but it's nice to know where the log statements come from sometimes.

I didn't change the log service.  It just uses a dummy "remote",-1 location when it writes log messages.
